### PR TITLE
feat(identity): check app ID/secret matching

### DIFF
--- a/identity/app_secret.go
+++ b/identity/app_secret.go
@@ -1,0 +1,19 @@
+package identity
+
+import (
+	"golang.org/x/crypto/blake2b"
+)
+
+const appSecretSize = 64
+const appPublicKeySize = 32
+const authorSize = 32
+const appCreationNature = 1
+
+func generateAppID(appSecret []byte) []byte {
+	publicKey := appSecret[appSecretSize-appPublicKeySize : appSecretSize]
+	author := make([]byte, 32)
+	payload := append([]byte{appCreationNature}, author...)
+	payload = append(payload, publicKey...)
+	hashed := blake2b.Sum256(payload)
+	return hashed[:]
+}

--- a/identity/generate.go
+++ b/identity/generate.go
@@ -43,7 +43,7 @@ func GetPublicIdentity(b64Identity string) (*string, error) {
 	}
 
 	if publicIdentity.Target != "user" && publicIdentity.Target != "email" {
-		return nil, errors.New("unsupported identity target")
+		return nil, errors.New("Unsupported identity target")
 	}
 
 	return b64json.Encode(publicIdentity)

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -1,7 +1,9 @@
 package identity
 
 import (
+	"bytes"
 	"encoding/base64"
+	"errors"
 
 	"github.com/TankerHQ/identity-go/curve25519"
 	"golang.org/x/crypto/ed25519"
@@ -34,6 +36,12 @@ type provisionalIdentity struct {
 }
 
 func generateIdentity(config config, userIDString string) (*identity, error) {
+	generatedAppID := generateAppID(config.AppSecret)
+
+	if !bytes.Equal(generatedAppID, config.AppID) {
+		return nil, errors.New("App secret and app ID mismatch")
+	}
+
 	userID := hashUserID(config.AppID, userIDString)
 	userSecret := createUserSecret(userID)
 

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -1,7 +1,6 @@
 package identity
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 
 	"golang.org/x/crypto/ed25519"
@@ -34,9 +33,13 @@ var _ = Describe("generateIdentity", func() {
 	)
 
 	BeforeEach(func() {
-		trustchainPublicKey, AppSecret, _ = ed25519.GenerateKey(nil)
-		AppID = make([]byte, 32)
-		_, _ = rand.Read(AppID)
+		trustchainPublicKeyStr := "r6oz1Rpl3dsMGu8te0LT02YZ/G8W9NeQmQv3uGSO/jE="
+		AppSecretStr := "cTMoGGUKhwN47ypq4xAXAtVkNWeyUtMltQnYwJhxWYSvqjPVGmXd2wwa7y17QtPTZhn8bxb015CZC/e4ZI7+MQ=="
+		AppIDStr := "tpoxyNzh0hU9G2i9agMvHyyd+pO6zGCjO9BfhrCLjd4="
+
+		trustchainPublicKey, _ = base64.StdEncoding.DecodeString(trustchainPublicKeyStr)
+		AppSecret, _ = base64.StdEncoding.DecodeString(AppSecretStr)
+		AppID, _ = base64.StdEncoding.DecodeString(AppIDStr)
 		obfuscatedUserID = hashUserID(AppID, userID)
 		conf = config{
 			AppID:     AppID,
@@ -60,5 +63,13 @@ var _ = Describe("generateIdentity", func() {
 		Expect(provisionalIdentity.TrustchainID).To(Equal(AppID))
 		Expect(provisionalIdentity.Target).To(Equal("email"))
 		Expect(provisionalIdentity.Value).To(Equal("email@example.com"))
+	})
+
+	It("throws if app ID and secret mismatch", func() {
+		mismatchingAppIDStr := "rB0/yEJWCUVYRtDZLtXaJqtneXQOsCSKrtmWw+V+ysc="
+		mismatchingAppID, _ := base64.StdEncoding.DecodeString(mismatchingAppIDStr)
+		invalidConf := config{AppID: mismatchingAppID, AppSecret: conf.AppSecret}
+		_, err := generateIdentity(invalidConf, "email@example.com")
+		Expect(err).Should(HaveOccurred())
 	})
 })


### PR DESCRIPTION
When generating an identity, we now check that the app secret and the
app ID matches, it avoids very hard to debug behavior.