### PR TITLE
Rework errors a little

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package identity
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
 )
 
@@ -19,17 +18,17 @@ type config struct {
 func (this Config) fromB64() (*config, error) {
 	appIDBytes, err := base64.StdEncoding.DecodeString(this.AppID)
 	if err != nil {
-		return nil, errors.New("Wrong AppID format, should be base64: " + this.AppID)
+		return nil, fmt.Errorf("unable to decode AppID '%s', should be a valid base64 string", this.AppID)
 	}
 	if len(appIDBytes) != AppPublicKeySize {
-		return nil, fmt.Errorf("Expected App ID of size %d, got %d", AppPublicKeySize, len(appIDBytes))
+		return nil, fmt.Errorf("wrong byte size for AppID: %d, should be %d", len(appIDBytes), AppPublicKeySize)
 	}
 	appSecretBytes, err := base64.StdEncoding.DecodeString(this.AppSecret)
 	if err != nil {
-		return nil, errors.New("Wrong AppSecret format, should be base64: " + this.AppSecret)
+		return nil, fmt.Errorf("unable to decode AppSecret '%s', should be a valid base64 string", this.AppSecret)
 	}
 	if len(appSecretBytes) != AppSecretSize {
-		return nil, fmt.Errorf("Expected App secret of size %d, got %d", AppSecretSize, len(appSecretBytes))
+		return nil, fmt.Errorf("wrong byte size for AppSecret: %d, should be %d", len(appSecretBytes), AppSecretSize)
 	}
 	return &config{
 		AppID:     appIDBytes,

--- a/generate.go
+++ b/generate.go
@@ -52,7 +52,7 @@ func GetPublicIdentity(b64Identity string) (*string, error) {
 	if publicIdentity.Target != "user" &&
 		publicIdentity.Target != "email" &&
 		publicIdentity.Target != "phone_number" {
-		return nil, errors.New("Unsupported identity target")
+		return nil, errors.New("unsupported identity target")
 	}
 
 	if publicIdentity.Target != "user" {

--- a/identity.go
+++ b/identity.go
@@ -40,7 +40,7 @@ func generateIdentity(config config, userIDString string) (*identity, error) {
 	generatedAppID := generateAppID(config.AppSecret)
 
 	if !bytes.Equal(generatedAppID, config.AppID) {
-		return nil, errors.New("App secret and app ID mismatch")
+		return nil, errors.New("app secret and app ID mismatch")
 	}
 
 	userID := hashUserID(config.AppID, userIDString)


### PR DESCRIPTION
Following our Go manifesto.
Note that Go generally avoids capitalizing errors strings for readability purposes when chaining errors.