### PR TITLE
Michel/implement benchmarks

### DIFF
--- a/identity_bench_test.go
+++ b/identity_bench_test.go
@@ -1,0 +1,40 @@
+package identity_test
+
+import (
+	"github.com/TankerHQ/identity-go/v3"
+	"testing"
+)
+
+func BenchmarkCreate(b *testing.B) {
+	for i := 0 ; i < b.N ; i++ {
+		identity.Create(validConf, "userID")
+	}
+}
+
+func BenchmarkCreateProvisional(b *testing.B) {
+	for _, target := range validTargets {
+		b.Run(target, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				identity.CreateProvisional(validConf, target, "userID")
+			}
+		})
+	}
+}
+
+func BenchmarkGetPublicIdentity(b *testing.B) {
+	for _, target := range validTargets {
+		provIdentity, _ := identity.CreateProvisional(validConf, target, "userID")
+		b.Run(target, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				identity.GetPublicIdentity(*provIdentity)
+			}
+		})
+	}
+}
+
+func BenchmarkUpgradeIdentity(b *testing.B) {
+	ident, _ := identity.Create(validConf, "userID")
+	for i := 0 ; i < b.N ; i++ {
+		identity.UpgradeIdentity(*ident)
+	}
+}

--- a/internal/app/app_secret_bench_test.go
+++ b/internal/app/app_secret_bench_test.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	"crypto/ed25519"
+	"testing"
+)
+
+func BenchmarkGetAppId(b *testing.B) {
+	_, secret, _ := ed25519.GenerateKey(nil)
+
+	for i := 0 ; i < b.N ; i++ {
+		GetAppId(secret)
+	}
+}

--- a/internal/base64_json/base64_json_bench_test.go
+++ b/internal/base64_json/base64_json_bench_test.go
@@ -1,0 +1,71 @@
+package base64_json_test
+
+import (
+	"github.com/TankerHQ/identity-go/v3/internal/base64_json"
+	"github.com/iancoleman/orderedmap"
+	"testing"
+)
+
+type benchStruct struct {
+	PublicSignatureKey string `json:"public_signature_key"`
+	PublicEncryptionKey string `json:"public_encryption_key"`
+	PrivateEncryptionKey string `json:"private_encryption_key"`
+}
+
+var (
+	benchStructValue = benchStruct{
+		PublicSignatureKey:   "str",
+		PublicEncryptionKey:  "str",
+		PrivateEncryptionKey: "str",
+	}
+
+	benchMap = map[string]string{
+		"public_signature_key": "str",
+		"public_encryption_key": "str",
+		"private_encryption_key": "str",
+	}
+
+	benchOrderedMap = func() *orderedmap.OrderedMap {
+		ordered := orderedmap.New()
+		for k, v := range benchMap {
+			ordered.Set(k, v)
+		}
+		return ordered
+	}()
+
+	benchVecs = []struct{
+		desc string
+		data interface{}
+	}{
+		{
+			desc: "Struct",
+			data: benchStructValue,
+		},
+		{
+			desc: "Map",
+			data: benchMap,
+		},
+		{
+			desc: "OrderedMap",
+			data: benchOrderedMap,
+		},
+	}
+)
+
+func BenchmarkEncode(b *testing.B) {
+	for _, vec := range benchVecs {
+		b.Run(vec.desc, func(b *testing.B) {
+			for i := 0 ; i < b.N ; i++ {
+				base64_json.Encode(vec.data)
+			}
+		})
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	encoded, _ := base64_json.Encode(benchStructValue)
+	into := make(map[string]interface{})
+	for i := 0 ; i < b.N ; i++ {
+		base64_json.Decode(*encoded, &into)
+	}
+}

--- a/internal/crypto/crypto_bench_test.go
+++ b/internal/crypto/crypto_bench_test.go
@@ -1,0 +1,12 @@
+package crypto_test
+
+import (
+	"github.com/TankerHQ/identity-go/v3/internal/crypto"
+	"testing"
+)
+
+func BenchmarkNewKeyPair(b *testing.B) {
+	for i := 0 ; i < b.N ; i++ {
+		crypto.NewKeyPair()
+	}
+}


### PR DESCRIPTION
Add benchmarks for all exported functions.
Some functions have "irrelevant" benchmarks in that they are simple enough not to be improvable. But for the sake of consistency and cleanliness I added them anyway, so in the future if those functions become more complex and imply more logic, we'll easily be able to monitor their performance.