### PR TITLE
Michel/improve performance

### DIFF
--- a/internal/base64_json/base64_json.go
+++ b/internal/base64_json/base64_json.go
@@ -27,19 +27,23 @@ func keyOrder(p1, p2 *orderedmap.Pair) bool {
 }
 
 func Encode(v interface{}) (*string, error) {
-	// Note: []byte values are encoded as base64-encoded strings
-	//       (see: https://golang.org/pkg/encoding/json/#Marshal)
-	buf, err := json.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
+	orderedMap, isOrderedMap := v.(*orderedmap.OrderedMap)
 
-	// Struct fields are marshalled in order of declaration, but we can't easily change the order
-	// OrderedMap fields are always marshalled in order, so we bounce through it
-	orderedMap := orderedmap.New()
-	err = json.Unmarshal(buf, orderedMap)
-	if err != nil {
-		return nil, err
+	if !isOrderedMap {
+		// Note: []byte values are encoded as base64-encoded strings
+		//       (see: https://golang.org/pkg/encoding/json/#Marshal)
+		buf, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+
+		// Struct fields are marshalled in order of declaration, but we can't easily change the order
+		// OrderedMap fields are always marshalled in order, so we bounce through it
+		orderedMap = orderedmap.New()
+		err = json.Unmarshal(buf, orderedMap)
+		if err != nil {
+			return nil, err
+		}
 	}
 	orderedMap.Sort(keyOrder)
 	orderedJson, err := json.Marshal(orderedMap)

--- a/internal/base64_json/base64_json.go
+++ b/internal/base64_json/base64_json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"github.com/iancoleman/orderedmap"
+	"sort"
 )
 
 var (
@@ -22,8 +23,10 @@ var (
 	}
 )
 
-func keyOrder(p1, p2 *orderedmap.Pair) bool {
-	return keyIndexes[p1.Key()] < keyIndexes[p2.Key()]
+func keySort(keys []string) {
+	sort.Slice(keys, func(i, j int) bool {
+		return keyIndexes[keys[i]] < keyIndexes[keys[j]]
+	})
 }
 
 func Encode(v interface{}) (*string, error) {
@@ -45,7 +48,7 @@ func Encode(v interface{}) (*string, error) {
 			return nil, err
 		}
 	}
-	orderedMap.Sort(keyOrder)
+	orderedMap.SortKeys(keySort)
 	orderedJson, err := json.Marshal(orderedMap)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```
Assertion of *orderedmap.OrderedMap in Encode

benchmark                        old ns/op     new ns/op     delta
BenchmarkEncode/Struct-8         8367          7919          -5.35%
BenchmarkEncode/Map-8            8680          8634          -0.53%
BenchmarkEncode/OrderedMap-8     8889          1946          -78.11%
BenchmarkDecode-8                1795          1720          -4.18%

benchmark                        old allocs     new allocs     delta
BenchmarkEncode/Struct-8         92             92             +0.00%
BenchmarkEncode/Map-8            104            104            +0.00%
BenchmarkEncode/OrderedMap-8     98             15             -84.69%
BenchmarkDecode-8                20             20             +0.00%

benchmark                        old bytes     new bytes     delta
BenchmarkEncode/Struct-8         3618          3618          +0.00%
BenchmarkEncode/Map-8            4170          4170          +0.00%
BenchmarkEncode/OrderedMap-8     3938          824           -79.08%
BenchmarkDecode-8                648           648           +0.00%


---

Change from Sort to SortKeys in Encode

benchmark                        old ns/op     new ns/op     delta
BenchmarkEncode/Struct-8         7688          7507          -2.35%
BenchmarkEncode/Map-8            8800          8805          +0.06%
BenchmarkEncode/OrderedMap-8     1827          1735          -5.04%
BenchmarkDecode-8                1715          1725          +0.58%

benchmark                        old allocs     new allocs     delta
BenchmarkEncode/Struct-8         92             89             -3.26%
BenchmarkEncode/Map-8            104            101            -2.88%
BenchmarkEncode/OrderedMap-8     15             12             -20.00%
BenchmarkDecode-8                20             20             +0.00%

benchmark                        old bytes     new bytes     delta
BenchmarkEncode/Struct-8         3618          3522          -2.65%
BenchmarkEncode/Map-8            4170          4074          -2.30%
BenchmarkEncode/OrderedMap-8     824           728           -11.65%
BenchmarkDecode-8                648           648           +0.00%

---

Add struct in GetPublicIdentity

benchmark                                     old ns/op     new ns/op     delta
BenchmarkCreate-8                             63625         64214         +0.93%
BenchmarkCreateProvisional/email-8            74171         73988         -0.25%
BenchmarkCreateProvisional/phone_number-8     73246         72307         -1.28%
BenchmarkGetPublicIdentity/email-8            18423         18395         -0.15%
BenchmarkGetPublicIdentity/phone_number-8     23891         22737         -4.83%
BenchmarkUpgradeIdentity-8                    23427         24262         +3.56%

benchmark                                     old allocs     new allocs     delta
BenchmarkCreate-8                             202            202            +0.00%
BenchmarkCreateProvisional/email-8            192            192            +0.00%
BenchmarkCreateProvisional/phone_number-8     192            192            +0.00%
BenchmarkGetPublicIdentity/email-8            149            149            +0.00%
BenchmarkGetPublicIdentity/phone_number-8     195            161            -17.44%
BenchmarkUpgradeIdentity-8                    182            182            +0.00%

benchmark                                     old bytes     new bytes     delta
BenchmarkCreate-8                             12553         12553         +0.00%
BenchmarkCreateProvisional/email-8            9287          9286          -0.01%
BenchmarkCreateProvisional/phone_number-8     9431          9431          +0.00%
BenchmarkGetPublicIdentity/email-8            7565          7565          +0.00%
BenchmarkGetPublicIdentity/phone_number-8     10431         9422          -9.67%
BenchmarkUpgradeIdentity-8                    11585         11585         +0.00%

---

Final, full benchmark for exported public functions

benchmark                                     old ns/op     new ns/op     delta
BenchmarkCreate-8                             62558         63317         +1.21%
BenchmarkCreateProvisional/email-8            72033         70814         -1.69%
BenchmarkCreateProvisional/phone_number-8     75112         73684         -1.90%
BenchmarkGetPublicIdentity/email-8            19794         19019         -3.92%
BenchmarkGetPublicIdentity/phone_number-8     25927         22974         -11.39%
BenchmarkUpgradeIdentity-8                    45763         22514         -50.80%

benchmark                                     old allocs     new allocs     delta
BenchmarkCreate-8                             209            202            -3.35%
BenchmarkCreateProvisional/email-8            199            192            -3.52%
BenchmarkCreateProvisional/phone_number-8     199            192            -3.52%
BenchmarkGetPublicIdentity/email-8            154            149            -3.25%
BenchmarkGetPublicIdentity/phone_number-8     200            161            -19.50%
BenchmarkUpgradeIdentity-8                    363            182            -49.86%

benchmark                                     old bytes     new bytes     delta
BenchmarkCreate-8                             12817         12553         -2.06%
BenchmarkCreateProvisional/email-8            9551          9286          -2.77%
BenchmarkCreateProvisional/phone_number-8     9695          9431          -2.72%
BenchmarkGetPublicIdentity/email-8            7749          7565          -2.37%
BenchmarkGetPublicIdentity/phone_number-8     10615         9422          -11.24%
BenchmarkUpgradeIdentity-8                    20664         11585         -43.94%
```