### PR TITLE
Type target concept

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,8 +6,11 @@ import (
 	"github.com/TankerHQ/identity-go/v3/internal/app"
 )
 
+// Config wraps information about an app
 type Config struct {
+	// AppID is the ID of the app corresponding to this config
 	AppID     string
+	// AppSecret is the app private signature key used to sign identities
 	AppSecret string
 }
 

--- a/identity.go
+++ b/identity.go
@@ -42,6 +42,7 @@ type provisionalIdentity struct {
 	PrivateEncryptionKey []byte `json:"private_encryption_key"`
 }
 
+// Create returns a new identity crafted from config and userID
 func Create(config Config, userID string) (*string, error) {
 	conf, err := config.fromBase64()
 	if err != nil {
@@ -54,6 +55,8 @@ func Create(config Config, userID string) (*string, error) {
 	return base64_json.Encode(identity)
 }
 
+// CreateProvisional returns a new provisional identity crafted from
+// config, target and value
 func CreateProvisional(config Config, target string, value string) (*string, error) {
 	conf, err := config.fromBase64()
 	if err != nil {
@@ -71,6 +74,8 @@ func CreateProvisional(config Config, target string, value string) (*string, err
 	return base64_json.Encode(provisional)
 }
 
+// GetPublicIdentity returns the public identity associated with the
+// identity it is sent
 func GetPublicIdentity(b64Identity string) (*string, error) {
 	type anyPublicIdentity struct {
 		publicIdentity
@@ -114,6 +119,8 @@ func GetPublicIdentity(b64Identity string) (*string, error) {
 	return base64_json.Encode(publicIdentity)
 }
 
+// UpgradeIdentity upgrades the identity provided to it if needed and returns
+// the result of the upgrade
 func UpgradeIdentity(b64Identity string) (*string, error) {
 	identity := orderedmap.New()
 	if err := base64_json.Decode(b64Identity, &identity); err != nil {

--- a/identity_bench_test.go
+++ b/identity_bench_test.go
@@ -1,0 +1,40 @@
+package identity_test
+
+import (
+	"github.com/TankerHQ/identity-go/v3"
+	"testing"
+)
+
+func BenchmarkCreate(b *testing.B) {
+	for i := 0 ; i < b.N ; i++ {
+		identity.Create(validConf, "userID")
+	}
+}
+
+func BenchmarkCreateProvisional(b *testing.B) {
+	for _, target := range validTargets {
+		b.Run(target, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				identity.CreateProvisional(validConf, target, "userID")
+			}
+		})
+	}
+}
+
+func BenchmarkGetPublicIdentity(b *testing.B) {
+	for _, target := range validTargets {
+		provIdentity, _ := identity.CreateProvisional(validConf, target, "userID")
+		b.Run(target, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				identity.GetPublicIdentity(*provIdentity)
+			}
+		})
+	}
+}
+
+func BenchmarkUpgradeIdentity(b *testing.B) {
+	ident, _ := identity.Create(validConf, "userID")
+	for i := 0 ; i < b.N ; i++ {
+		identity.UpgradeIdentity(*ident)
+	}
+}

--- a/identity_bench_test.go
+++ b/identity_bench_test.go
@@ -13,7 +13,7 @@ func BenchmarkCreate(b *testing.B) {
 
 func BenchmarkCreateProvisional(b *testing.B) {
 	for _, target := range validTargets {
-		b.Run(target, func(b *testing.B) {
+		b.Run(string(target), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				identity.CreateProvisional(validConf, target, "userID")
 			}
@@ -24,7 +24,7 @@ func BenchmarkCreateProvisional(b *testing.B) {
 func BenchmarkGetPublicIdentity(b *testing.B) {
 	for _, target := range validTargets {
 		provIdentity, _ := identity.CreateProvisional(validConf, target, "userID")
-		b.Run(target, func(b *testing.B) {
+		b.Run(string(target), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				identity.GetPublicIdentity(*provIdentity)
 			}

--- a/identity_test.go
+++ b/identity_test.go
@@ -78,12 +78,12 @@ var (
 		},
 	}
 
-	validTargets = []string{
-		"email",
-		"phone_number",
+	validTargets = []identity.Target{
+		identity.Email,
+		identity.PhoneNumber,
 	}
 
-	invalidTarget = "____not_a_good_target____"
+	invalidTarget = identity.Target("____not_a_good_target____")
 )
 
 // singleSuccessReader is a helper type to test the case when the first
@@ -156,7 +156,7 @@ func TestCreate_Error(t *testing.T) {
 
 func TestCreateProvisional(t *testing.T) {
 	for _, validTarget := range validTargets {
-		t.Run("Target/"+validTarget, func(t *testing.T) {
+		t.Run("Target/"+string(validTarget), func(t *testing.T) {
 			id, err := identity.CreateProvisional(validConf, validTarget, "userID")
 			if err != nil || id == nil || *id == "" {
 				t.Fatal("error creating provisional identity with valid config")
@@ -168,7 +168,7 @@ func TestCreateProvisional(t *testing.T) {
 func TestCreateProvisional_Error(t *testing.T) {
 	for _, conf := range badConfsVector {
 		for _, target := range validTargets {
-			t.Run(conf.desc+"/"+target, func(t *testing.T) {
+			t.Run(conf.desc+"/"+string(target), func(t *testing.T) {
 				_, err := identity.CreateProvisional(conf.config, target, "userID")
 				if err == nil {
 					t.Fatal("no error creating provisional identity")
@@ -243,7 +243,7 @@ func TestGetPublicIdentity_ProvisionalIdentity(t *testing.T) {
 			panic("error creating provisional identity")
 		}
 
-		t.Run(target, func(t *testing.T) {
+		t.Run(string(target), func(t *testing.T) {
 			assertStablePublic(t, provisional)
 		})
 	}
@@ -251,7 +251,7 @@ func TestGetPublicIdentity_ProvisionalIdentity(t *testing.T) {
 
 func TestGetPublicIdentity_Error(t *testing.T) {
 	t.Run("BadTarget", func(t *testing.T) {
-		fakeIdentity := map[string]string{
+		fakeIdentity := map[string]identity.Target{
 			"target": invalidTarget,
 		}
 
@@ -301,13 +301,13 @@ func TestUpgradeIdentity(t *testing.T) {
 			panic("error getting public identity")
 		}
 
-		t.Run("Private/"+target, func(t *testing.T) {
+		t.Run("Private/"+string(target), func(t *testing.T) {
 			_, err := identity.UpgradeIdentity(*prov)
 			if err != nil {
 				t.Fatal("error upgrading identity")
 			}
 		})
-		t.Run("Public/"+target, func(t *testing.T) {
+		t.Run("Public/"+string(target), func(t *testing.T) {
 			_, err := identity.UpgradeIdentity(*pubProv)
 			if err != nil {
 				t.Fatal("error upgrading identity")

--- a/internal/app/app_secret.go
+++ b/internal/app/app_secret.go
@@ -5,7 +5,9 @@ import (
 )
 
 const (
+	// AppSecretSize is the length of an app secret, in bytes
 	AppSecretSize = 64
+	// AppPublicKeySize is the length of an app public key, in bytes
 	AppPublicKeySize = 32
 )
 
@@ -14,6 +16,8 @@ const (
 	appCreationNature = 1
 )
 
+// GetAppId returns the app ID from the appSecret it is provided with.
+// appSecret should be precisely AppSecretSize bytes long.
 func GetAppId(appSecret []byte) []byte {
 	publicKey := appSecret[AppSecretSize-AppPublicKeySize : AppSecretSize]
 

--- a/internal/app/app_secret_bench_test.go
+++ b/internal/app/app_secret_bench_test.go
@@ -1,0 +1,15 @@
+package app
+
+import (
+	"crypto/rand"
+	"testing"
+)
+
+func BenchmarkGetAppId(b *testing.B) {
+	appSecret := make([]byte, AppSecretSize)
+	rand.Read(appSecret)
+
+	for i := 0 ; i < b.N ; i++ {
+		GetAppId(appSecret)
+	}
+}

--- a/internal/base64_json/base64_json.go
+++ b/internal/base64_json/base64_json.go
@@ -26,6 +26,12 @@ func keyOrder(p1, p2 *orderedmap.Pair) bool {
 	return keyIndexes[p1.Key()] < keyIndexes[p2.Key()]
 }
 
+// Encode returns a pointer to the base64 representation of the result of
+// marshalling v. If an error occurs in the process, it is returned.
+// Under the hood, Encode transforms v into a *orderedmap.OrderedMap so
+// the result will always wrap a key-sorted JSON representation to this
+// package. If v's underlying type is already *orderedmap.OrderedMap, v's
+// wrapped value will be used as is.
 func Encode(v interface{}) (*string, error) {
 	// Note: []byte values are encoded as base64-encoded strings
 	//       (see: https://golang.org/pkg/encoding/json/#Marshal)
@@ -51,6 +57,10 @@ func Encode(v interface{}) (*string, error) {
 	return &b64Encoded, nil
 }
 
+// Decode takes a value typically returned by Encode, that is,
+// a base64-encoded JSON-marshalled value, and applies the reverse operation,
+// first base64-decoding b64, then unmarshalling the resulting JSON
+// representation into v. If an error occurs on the way, it is returned.
 func Decode(b64 string, v interface{}) error {
 	buf, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {

--- a/internal/base64_json/base64_json_bench_test.go
+++ b/internal/base64_json/base64_json_bench_test.go
@@ -1,0 +1,71 @@
+package base64_json_test
+
+import (
+	"github.com/TankerHQ/identity-go/v3/internal/base64_json"
+	"github.com/iancoleman/orderedmap"
+	"testing"
+)
+
+type benchStruct struct {
+	PublicSignatureKey string `json:"public_signature_key"`
+	PublicEncryptionKey string `json:"public_encryption_key"`
+	PrivateEncryptionKey string `json:"private_encryption_key"`
+}
+
+var (
+	benchStructValue = benchStruct{
+		PublicSignatureKey:   "str",
+		PublicEncryptionKey:  "str",
+		PrivateEncryptionKey: "str",
+	}
+
+	benchMap = map[string]string{
+		"public_signature_key": "str",
+		"public_encryption_key": "str",
+		"private_encryption_key": "str",
+	}
+
+	benchOrderedMap = func() *orderedmap.OrderedMap {
+		ordered := orderedmap.New()
+		for k, v := range benchMap {
+			ordered.Set(k, v)
+		}
+		return ordered
+	}()
+
+	benchVecs = []struct{
+		desc string
+		data interface{}
+	}{
+		{
+			desc: "Struct",
+			data: benchStructValue,
+		},
+		{
+			desc: "Map",
+			data: benchMap,
+		},
+		{
+			desc: "OrderedMap",
+			data: benchOrderedMap,
+		},
+	}
+)
+
+func BenchmarkEncode(b *testing.B) {
+	for _, vec := range benchVecs {
+		b.Run(vec.desc, func(b *testing.B) {
+			for i := 0 ; i < b.N ; i++ {
+				base64_json.Encode(vec.data)
+			}
+		})
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	encoded, _ := base64_json.Encode(benchStructValue)
+	into := make(map[string]interface{})
+	for i := 0 ; i < b.N ; i++ {
+		base64_json.Decode(*encoded, &into)
+	}
+}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -6,6 +6,9 @@ import (
 	"golang.org/x/crypto/curve25519"
 )
 
+// NewKeyPair returns a pair of cryptographic keys that can later
+// be used for signature and verification, along with an error,
+// if one occurs
 func NewKeyPair() ([]byte, []byte, error) {
 	var (
 		sk [32]byte

--- a/internal/crypto/crypto_bench_test.go
+++ b/internal/crypto/crypto_bench_test.go
@@ -1,0 +1,12 @@
+package crypto_test
+
+import (
+	"github.com/TankerHQ/identity-go/v3/internal/crypto"
+	"testing"
+)
+
+func BenchmarkNewKeyPair(b *testing.B) {
+	for i := 0 ; i < b.N ; i++ {
+		crypto.NewKeyPair()
+	}
+}

--- a/target.go
+++ b/target.go
@@ -1,0 +1,16 @@
+package identity
+
+// Target is the target for an identity. It can take values among
+// "email", "phone_number" and "user"
+type Target string
+
+const (
+	Email Target = "email"
+	PhoneNumber Target = "phone_number"
+	User Target = "user"
+)
+
+// Hashed returns the hashed equivalent of t
+func (t Target) Hashed() Target {
+	return "hashed_" + t
+}


### PR DESCRIPTION
Functions in the code take a `target` which is originally a string, which authorized values are among an enumeration. The user of the code has to know those values to use the SDK correctly and that is a negative point, as the SDK to be the most self-explaining possible.
This branch implements a new type `Target` on top of the builtin `string`. It has a `Hashed` method returning its hashed equivalent. A number of `const` of the possible valid value for a `Target` are exported so the user can take advantage of them directly.