### PR TITLE
chore(ci): replace legacy coverage upload method

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,5 @@ jobs:
           go-version: 1.18
       - name: Run tests
         run: go test -coverprofile=coverage.txt -covermode=atomic ./...
-      - name: Upload coverage
-        run: bash <(curl -s https://codecov.io/bash)
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
It is now recommended to use the "new" uploader, either directly
or via the built-in GitHub Actions integration.

See:
* https://about.codecov.io/blog/introducing-codecovs-new-uploader/
* https://about.codecov.io/blog/codecov-uploader-deprecation-plan/